### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/The-Privacy-Aware-RAG-Bot/security/code-scanning/1](https://github.com/vannu07/The-Privacy-Aware-RAG-Bot/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions` block in the workflow (either at the top level or per job) and restrict the `GITHUB_TOKEN` to the minimum needed. For a typical CI job that only checks out code and runs tests, `contents: read` is sufficient, as no writes to the repository or other resources are required.

For this specific workflow, the simplest and least disruptive fix is to add a `permissions` section at the root of the workflow, right after the `name: CI` line. This will apply to all jobs (there is only `test`) and restrict the token to read-only repository contents. No other scopes such as `pull-requests` or `issues` are needed based on the shown steps, since the workflow does not comment on PRs, push commits, or upload releases. No additional imports or external dependencies are required; this is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: CI`) and line 3 (`on:`).  
This documents and enforces least-privilege permissions without changing any of the job’s existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a security permission boundary to the CI workflow to address a code scanning alert.

## What changed

Added a `permissions` block to `.github/workflows/ci.yml` that grants the workflow `contents: read` access. This explicitly defines what the GitHub Actions workflow is allowed to do, limiting the `GITHUB_TOKEN` to read-only access to the repository.

## Why it was needed

GitHub recommends that workflows explicitly declare their required permissions as a security best practice. By default, workflows have broad permissions, which violates the principle of least privilege. Since the CI job only needs to check out code and run tests, it only requires read access to repository contents.

## Impact

The workflow functions identically, but is now more secure. It explicitly restricts what the `GITHUB_TOKEN` can do to only what's necessary, reducing the potential blast radius if the token were ever compromised. No changes to job steps or workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->